### PR TITLE
Deprecate Node.js 4 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - 8
   - 6
-  - 4
   - 10
 cache: yarn


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 4